### PR TITLE
例外メッセージの定数管理を集約

### DIFF
--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/constant/ExceptionIdConstants.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/constant/ExceptionIdConstants.java
@@ -8,23 +8,20 @@ public class ExceptionIdConstants {
   /** 日記ID:{0}の日記が見つかりませんでした。 */
   public static final String E_DIARY_NOT_FOUND = "diaryNotFound";
 
+  /** 日記の{0}は必須です。 */
+  public static final String E_DIARY_FIELD_IS_REQUIRED = "diaryFieldIsRequired";
+
+  /** 日記の{0}は{1}~{2}の範囲で入力してください。 */
+  public static final String E_DIARY_VALUE_IS_OUT_OF_RANGE = "diaryValueIsOutOfRange";
+
   /** ユーザーID：{0}のユーザーが見つかりませんでした。 */
   public static final String E_USER_NOT_FOUND = "userNotFound";
 
-  /** ユーザーID：{0}は必須です。 */
-  public static final String E_USER_ID_IS_NULL = "userIdIsNull";
+  /** ユーザーの{0}は必須です。 */
+  public static final String E_USER_NAME_IS_REQUIRED = "userNameIsRequired";
 
-  /** ユーザーID：{0}は0以上の値にしてください。 */
-  public static final String E_USER_ID_IS_NEGATIVE = "userIdIsNegative";
-
-  /** ユーザー名：{0}は必須です。 */
-  public static final String E_USER_NAME_IS_NULL = "userNameIsNull";
-
-  /** ユーザー名：{0}は必須です。 */
-  public static final String E_USER_NAME_IS_BLANK = "userNameIsBlank";
-
-  /** ユーザー名：{0}は1～15文字の範囲で入力してください。*/
-  public static final String E_USER_NAME_LENGTH_IS_OUT_OF_RANGE = "userNameLengthIsOutOfRange";
+  /** ユーザーの{0}は{1}~{2}の範囲で入力してください。 */
+  public static final String E_USER_VALUE_IS_OUT_OF_RANGE = "userValueIsOutOfRange";
 
   /** {0} を実行する権限がありません。 */
   public static final String E_PERMISSION_DENIED = "permissionDenied";

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/constant/ExceptionIdConstants.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/constant/ExceptionIdConstants.java
@@ -18,7 +18,7 @@ public class ExceptionIdConstants {
   public static final String E_USER_NOT_FOUND = "userNotFound";
 
   /** ユーザーの{0}は必須です。 */
-  public static final String E_USER_NAME_IS_REQUIRED = "userNameIsRequired";
+  public static final String E_USER_FIELD_IS_REQUIRED = "userFieldIsRequired";
 
   /** ユーザーの{0}は{1}~{2}の範囲で入力してください。 */
   public static final String E_USER_VALUE_IS_OUT_OF_RANGE = "userValueIsOutOfRange";

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/Diary.java
@@ -33,11 +33,13 @@ public class Diary {
    * @param id          ID。
    * @param userId      ユーザー ID。
    * @param title       タイトル。
-   * @param content     内容。
+   * @param content     コンテンツ。
    * @param createdDate 作成日時。
    * @param isDeleted   削除フラグ。
+   * @throws DiaryValidationException 日記が不正な場合。
    */
-  public Diary(long id, long userId, String title, String content, LocalDate createdDate, boolean isDeleted) {
+  public Diary(long id, long userId, String title, String content, LocalDate createdDate, boolean isDeleted)
+      throws DiaryValidationException {
     this.id = new Id(id);
     this.userId = new UserId(userId);
     this.title = new Title(title);
@@ -74,9 +76,9 @@ public class Diary {
   }
 
   /**
-   * 内容を取得します。
+   * コンテンツを取得します。
    * 
-   * @return 内容。
+   * @return コンテンツ。
    */
   public String getContent() {
     return this.content.getValue();
@@ -122,17 +124,19 @@ public class Diary {
    * タイトルを設定します。
    * 
    * @param title タイトル。
+   * @throws DiaryValidationException タイトルが不正な場合。
    */
-  public void setTitle(String title) {
+  public void setTitle(String title) throws DiaryValidationException {
     this.title = new Title(title);
   }
 
   /**
-   * 内容を設定します。
+   * コンテンツを設定します。
    * 
-   * @param content 内容。
+   * @param content コンテンツ。
+   * @throws DiaryValidationException コンテンツが不正な場合。
    */
-  public void setContent(String content) {
+  public void setContent(String content) throws DiaryValidationException {
     this.content = new Content(content);
   }
 
@@ -140,8 +144,9 @@ public class Diary {
    * 作成日時を設定します。
    * 
    * @param createdDate 作成日時。
+   * @throws DiaryValidationException 作成日時が不正な場合。
    */
-  public void setCreatedDate(LocalDate createdDate) {
+  public void setCreatedDate(LocalDate createdDate) throws DiaryValidationException {
     this.createdDate = new CreatedDate(createdDate);
   }
 

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryValidationException.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryValidationException.java
@@ -1,0 +1,22 @@
+package com.memoblend.applicationcore.diary;
+
+import com.memoblend.systemcommon.exception.ValidationException;
+
+/**
+ * 日記のバリデーションエラー時の例外です。
+ */
+public class DiaryValidationException extends ValidationException {
+
+  /**
+   * 例外 ID 、メッセージ用プレースフォルダ（フロント用）、
+   * メッセージ用プレースフォルダ（ログ用）を指定して、
+   * {@link DiaryValidationException} クラスのインスタンスを初期化します。
+   * 
+   * @param exceptionId       例外 ID 。
+   * @param frontMessageValue メッセージ用プレースフォルダ（フロント用）。
+   * @param logMessageValue   メッセージ用プレースフォルダ（ログ用）。
+   */
+  public DiaryValidationException(String exceptionId, String[] frontMessageValue, String[] logMessageValue) {
+    super(exceptionId, frontMessageValue, logMessageValue);
+  }
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Content.java
@@ -1,5 +1,7 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
+import com.memoblend.applicationcore.constant.ExceptionIdConstants;
+import com.memoblend.applicationcore.diary.DiaryValidationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -15,14 +17,20 @@ public class Content {
    * {@link Content} クラスの新しいインスタンスを初期化します。
    * 
    * @param value コンテンツの値。
-   * @throws IllegalArgumentException コンテンツの値が null か指定の文字数範囲外の場合。
+   * @throws DiaryValidationException コンテンツが不正な場合。
    */
-  public Content(String value) {
+  public Content(String value) throws DiaryValidationException {
     if (value == null || value.isEmpty() || value.isBlank()) {
-      throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
+      throw new DiaryValidationException(
+          ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED,
+          new String[] { String.valueOf("コンテンツ") },
+          new String[] { String.valueOf("コンテンツ") });
     }
-    if (value.length() < 1 || value.length() > 1000) {
-      throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
+    if (value.length() <= 1 || value.length() >= 1000) {
+      throw new DiaryValidationException(
+          ExceptionIdConstants.E_DIARY_VALUE_IS_OUT_OF_RANGE,
+          new String[] { String.valueOf("コンテンツ"), "1", "1000" },
+          new String[] { String.valueOf("コンテンツ"), "1", "1000" });
     }
     this.value = value;
   }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/CreatedDate.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/CreatedDate.java
@@ -1,6 +1,8 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
 import java.time.LocalDate;
+import com.memoblend.applicationcore.constant.ExceptionIdConstants;
+import com.memoblend.applicationcore.diary.DiaryValidationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -16,11 +18,14 @@ public class CreatedDate {
    * {@link CreatedDate} クラスの新しいインスタンスを初期化します。
    * 
    * @param value 作成日時の値。
-   * @throws IllegalArgumentException 作成日時の値が null の場合。
+   * @throws DiaryValidationException 作成日時が不正な場合。
    */
-  public CreatedDate(LocalDate value) {
+  public CreatedDate(LocalDate value) throws DiaryValidationException {
     if (value == null) {
-      throw new IllegalArgumentException("{0} は必須です");
+      throw new DiaryValidationException(
+          ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED,
+          new String[] { String.valueOf("作成日時") },
+          new String[] { String.valueOf("作成日時") });
     }
     this.value = value;
   }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Id.java
@@ -15,12 +15,8 @@ public class Id {
    * {@link Id} クラスの新しいインスタンスを初期化します。
    * 
    * @param value ID の値。
-   * @throws IllegalArgumentException ID の値が 0 未満の場合。
    */
   public Id(long value) {
-    if (value < 0) {
-      throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
-    }
     this.value = value;
   }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/Title.java
@@ -1,5 +1,7 @@
 package com.memoblend.applicationcore.diary.valueobject;
 
+import com.memoblend.applicationcore.constant.ExceptionIdConstants;
+import com.memoblend.applicationcore.diary.DiaryValidationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -15,14 +17,20 @@ public class Title {
    * {@link Title} クラスの新しいインスタンスを初期化します。
    * 
    * @param value タイトルの値。
-   * @throws IllegalArgumentException タイトルの値が null か指定の文字数範囲外の場合。
+   * @throws DiaryValidationException タイトルが不正な場合。
    */
-  public Title(String value) {
+  public Title(String value) throws DiaryValidationException {
     if (value == null || value.isEmpty() || value.isBlank()) {
-      throw new IllegalArgumentException("{0} は {1} 文字以上入力してください");
+      throw new DiaryValidationException(
+          ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED,
+          new String[] { String.valueOf("タイトル") },
+          new String[] { String.valueOf("タイトル") });
     }
-    if (value.length() < 1 || value.length() > 30) {
-      throw new IllegalArgumentException("{0} は {1} ～ {2} 文字の範囲で入力してください");
+    if (value.length() <= 1 || value.length() >= 30) {
+      throw new DiaryValidationException(
+          ExceptionIdConstants.E_DIARY_VALUE_IS_OUT_OF_RANGE,
+          new String[] { String.valueOf("タイトル"), "1", "30" },
+          new String[] { String.valueOf("タイトル"), "1", "30" });
     }
     this.value = value;
   }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/valueobject/UserId.java
@@ -15,12 +15,8 @@ public class UserId {
    * {@link UserId} クラスの新しいインスタンスを初期化します。
    * 
    * @param value ユーザー ID の値。
-   * @throws IllegalArgumentException ユーザー ID の値が 0 未満の場合。
    */
   public UserId(long value) {
-    if (value < 0) {
-      throw new IllegalArgumentException("{0} は {1} 以上の値にしてください");
-    }
     this.value = value;
   }
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/user/User.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/user/User.java
@@ -23,8 +23,9 @@ public class User {
    * @param id        ユーザーの ID 。
    * @param name      ユーザーの名前。
    * @param isDeleted 削除済みの場合 true 、 未削除の場合 false 。
+   * @throws UserValidationException ユーザーが不正な場合。
    */
-  public User(long id, String name, boolean isDeleted) {
+  public User(long id, String name, boolean isDeleted) throws UserValidationException {
     this.id = new Id(id);
     this.name = new Name(name);
     this.isDeleted = new IsDeleted(isDeleted);
@@ -70,8 +71,9 @@ public class User {
    * ユーザーの名前を設定します。
    *
    * @param name 新しいユーザー名。
+   * @throws UserValidationException ユーザー名が不正な場合。
    */
-  public void setName(String name) {
+  public void setName(String name) throws UserValidationException {
     this.name = new Name(name);
   }
 

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/user/UserValidationException.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/user/UserValidationException.java
@@ -1,0 +1,22 @@
+package com.memoblend.applicationcore.user;
+
+import com.memoblend.systemcommon.exception.ValidationException;
+
+/**
+ * ユーザーのバリデーションエラー時の例外です。
+ */
+public class UserValidationException extends ValidationException {
+
+  /**
+   * 例外 ID 、メッセージ用プレースフォルダ（フロント用）、
+   * メッセージ用プレースフォルダ（ログ用）を指定して、
+   * {@link DiaryValidationException} クラスのインスタンスを初期化します。
+   * 
+   * @param exceptionId       例外 ID 。
+   * @param frontMessageValue メッセージ用プレースフォルダ（フロント用）。
+   * @param logMessageValue   メッセージ用プレースフォルダ（ログ用）。
+   */
+  public UserValidationException(String exceptionId, String[] frontMessageValue, String[] logMessageValue) {
+    super(exceptionId, frontMessageValue, logMessageValue);
+  }
+}

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/user/valueobject/Id.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/user/valueobject/Id.java
@@ -1,6 +1,5 @@
 package com.memoblend.applicationcore.user.valueobject;
 
-import com.memoblend.applicationcore.constant.ExceptionIdConstants;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -14,16 +13,11 @@ public class Id {
   private final long value;
 
   /**
-   * ID の値オブジェクトを生成します。
+   * {@link Id} クラスの新しいインスタンスを初期化します。
    * 
    * @param value ユーザーの ID 。
-   * @throws IllegalArgumentException ID が 0 未満の場合。
    */
   public Id(long value) {
-    if (value < 0) {
-      throw new IllegalArgumentException(ExceptionIdConstants.E_USER_ID_IS_NEGATIVE);
-    }
     this.value = value;
   }
-
 }

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/user/valueobject/IsDeleted.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/user/valueobject/IsDeleted.java
@@ -13,7 +13,7 @@ public class IsDeleted {
   private final boolean value;
 
   /**
-   * 削除フラグの値オブジェクトを生成します。
+   * {@link IsDeleted} クラスの新しいインスタンスを初期化します。
    * 
    * @param value 削除フラグ。
    */

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/user/valueobject/Name.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/user/valueobject/Name.java
@@ -1,6 +1,7 @@
 package com.memoblend.applicationcore.user.valueobject;
 
 import com.memoblend.applicationcore.constant.ExceptionIdConstants;
+import com.memoblend.applicationcore.user.UserValidationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -14,20 +15,23 @@ public class Name {
   private final String value;
 
   /**
-   * 名前の値オブジェクトを生成します。
+   * {@link Name} クラスの新しいインスタンスを初期化します。
    * 
-   * @param value ユーザーの名前。
-   * @throws IllegalArgumentException 名前が null 、空文字、空白文字、文字数範囲外の場合。
+   * @param value ユーザー名。
+   * @throws UserValidationException ユーザー名が不正な場合。
    */
-  public Name(String value) {
-    if (value == null) {
-      throw new IllegalArgumentException(ExceptionIdConstants.E_USER_NAME_IS_NULL);
+  public Name(String value) throws UserValidationException {
+    if (value == null || value.isEmpty() || value.isBlank()) {
+      throw new UserValidationException(
+          ExceptionIdConstants.E_USER_FIELD_IS_REQUIRED,
+          new String[] { String.valueOf("ユーザー名") },
+          new String[] { String.valueOf("ユーザー名") });
     }
-    if (value.isBlank()) {
-      throw new IllegalArgumentException(ExceptionIdConstants.E_USER_NAME_IS_BLANK);
-    }
-    if (value.length() < 1 || value.length() > 15) {
-      throw new IllegalArgumentException(ExceptionIdConstants.E_USER_NAME_LENGTH_IS_OUT_OF_RANGE);
+    if (value.length() <= 1 || value.length() >= 15) {
+      throw new UserValidationException(
+          ExceptionIdConstants.E_USER_VALUE_IS_OUT_OF_RANGE,
+          new String[] { String.valueOf("ユーザー名"), "1", "15" },
+          new String[] { String.valueOf("ユーザー名"), "1", "15" });
     }
     this.value = value;
   }

--- a/backend/application-core/src/main/resources/applicationcore/messages.properties
+++ b/backend/application-core/src/main/resources/applicationcore/messages.properties
@@ -1,7 +1,10 @@
 #### 日記 ####
+
 # エラーメッセージ
 diaryNotFound=日記ID:{0}の日記が見つかりませんでした。
-permissionDenied={0} を実行する権限がありません。
+diaryFieldIsRequired=日記の{0}は必須です。
+diaryValueIsOutOfRange=日記の{0}は{1}～{2}の範囲で入力してください。
+
 # 通知用メッセージ
 diaryApplicationServiceGetDiaries=日記の一覧を取得します。
 diaryApplicationServiceGetDiary=日記ID:{0}の日記を取得します。
@@ -10,16 +13,18 @@ diaryApplicationServiceUpdateDiary=日記ID:{0}の日記を更新します。
 diaryApplicationServiceDeleteDiary=日記ID:{0}の日記を削除します。
 
 #### ユーザー ####
+
 # エラーメッセージ
 userNotFound=ユーザーID:{0}のユーザーが見つかりませんでした。
-userIdIsNull=ユーザーID{0}は必須です。
-userIdIsNegative=ユーザーID：{0}は0以上の値にしてください。
-userNameIsNull=ユーザー名：{0}は必須です。
-userNameIsBlank=ユーザー名：{0}は必須です。
-userNameLengthIsOutOfRange=ユーザー名：{0}は1～15文字の範囲で入力してください。
+userFieldIsRequired=ユーザーの{0}は必須です。
+userValueIsOutOfRange=ユーザーの{0}は{1}～{2}の範囲で入力してください。
+
 # 通知用メッセージ
 userApplicationServiceGetUsers=ユーザーの一覧を取得します。
 userApplicationServiceGetUser=ユーザーID:{0}のユーザーを取得します。
 userApplicationServiceAddUser=ユーザーID:{0}のユーザーを追加します。
 userApplicationServiceUpdateUser=ユーザーID:{0}のユーザーを更新します。
 userApplicationServiceDeleteUser=ユーザーID:{0}のユーザーを削除します。
+
+#### 共通 ####
+permissionDenied={0} を実行する権限がありません。

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationServiceTest.java
@@ -27,6 +27,7 @@ import com.memoblend.applicationcore.diary.Diary;
 import com.memoblend.applicationcore.diary.DiaryDomainService;
 import com.memoblend.applicationcore.diary.DiaryNotFoundException;
 import com.memoblend.applicationcore.diary.DiaryRepository;
+import com.memoblend.applicationcore.diary.DiaryValidationException;
 
 /**
  * 日記のアプリケーションサービスのテストクラスです。
@@ -56,7 +57,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testGetDiaries_正常系_リポジトリのfindAllを1回呼び出す() throws PermissionDeniedException {
+  void testGetDiaries_正常系_リポジトリのfindAllを1回呼び出す() throws PermissionDeniedException, DiaryValidationException {
     // Arrange
     List<LocalDate> dates = new ArrayList<>();
     dates.add(LocalDate.of(2025, 1, 1));
@@ -70,7 +71,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testGetDiaries_正常系_日記のリストを返す() throws PermissionDeniedException {
+  void testGetDiaries_正常系_日記のリストを返す() throws PermissionDeniedException, DiaryValidationException {
     // Arrange
     List<LocalDate> dates = new ArrayList<>();
     dates.add(LocalDate.of(2025, 1, 1));
@@ -84,7 +85,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testGetDiaries_異常系_権限がない場合にPermissionDeniedExceptionが発生する() {
+  void testGetDiaries_異常系_権限がない場合にPermissionDeniedExceptionが発生する() throws DiaryValidationException {
     // Arrange
     List<LocalDate> dates = new ArrayList<>();
     dates.add(LocalDate.of(2025, 1, 1));
@@ -100,7 +101,8 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testGetDiary_正常系_リポジトリのfindByIdを1回呼び出す() throws DiaryNotFoundException, PermissionDeniedException {
+  void testGetDiary_正常系_リポジトリのfindByIdを1回呼び出す()
+      throws DiaryNotFoundException, PermissionDeniedException, DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -114,7 +116,8 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testGetDiary_正常系_指定した日付の日記を返す() throws DiaryNotFoundException, PermissionDeniedException {
+  void testGetDiary_正常系_指定した作成日時の日記を返す()
+      throws DiaryNotFoundException, PermissionDeniedException, DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -142,7 +145,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testGetDiary_異常系_権限がない場合にPermnissionDeniedExceptionが発生する() {
+  void testGetDiary_異常系_権限がない場合にPermnissionDeniedExceptionが発生する() throws DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -158,7 +161,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testAddDiary_正常系_リポジトリのaddを1回呼び出す() throws PermissionDeniedException {
+  void testAddDiary_正常系_リポジトリのaddを1回呼び出す() throws PermissionDeniedException, DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -173,7 +176,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testAddDiary_正常系_追加された日記を返す() throws PermissionDeniedException {
+  void testAddDiary_正常系_追加された日記を返す() throws PermissionDeniedException, DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -188,7 +191,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testAddDiary_異常系_権限がない場合にPermissionDeniedExceptionが発生する() {
+  void testAddDiary_異常系_権限がない場合にPermissionDeniedExceptionが発生する() throws DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -205,7 +208,8 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testUpdateDiary_正常系_リポジトリのupdateを1回呼び出す() throws DiaryNotFoundException, PermissionDeniedException {
+  void testUpdateDiary_正常系_リポジトリのupdateを1回呼び出す()
+      throws DiaryNotFoundException, PermissionDeniedException, DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -219,7 +223,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testUpdateDiary_異常系_更新しようとした日記が存在しない場合DiaryNotFoundExceptionがスローされる() {
+  void testUpdateDiary_異常系_更新しようとした日記が存在しない場合DiaryNotFoundExceptionがスローされる() throws DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -235,7 +239,7 @@ public class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testUpdateDiary_異常系_権限がない場合にPermissionDeniedExceptionが発生する() {
+  void testUpdateDiary_異常系_権限がない場合にPermissionDeniedExceptionが発生する() throws DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -290,7 +294,7 @@ public class DiaryApplicationServiceTest {
     assertThrows(PermissionDeniedException.class, action);
   }
 
-  private List<Diary> createDiaries(List<LocalDate> dates) {
+  private List<Diary> createDiaries(List<LocalDate> dates) throws DiaryValidationException {
     List<Diary> diaries = new ArrayList<>();
     for (LocalDate createdDate : dates) {
       diaries.add(createDiary(createdDate));
@@ -298,7 +302,7 @@ public class DiaryApplicationServiceTest {
     return diaries;
   }
 
-  private Diary createDiary(LocalDate createdDate) {
+  private Diary createDiary(LocalDate createdDate) throws DiaryValidationException {
     long id = 1;
     long userId = 1;
     String title = "testTitle";

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/UserApplicationServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/UserApplicationServiceTest.java
@@ -23,6 +23,7 @@ import com.memoblend.applicationcore.user.User;
 import com.memoblend.applicationcore.user.UserNotFoundException;
 import com.memoblend.applicationcore.user.UserDomainService;
 import com.memoblend.applicationcore.user.UserRepository;
+import com.memoblend.applicationcore.user.UserValidationException;
 
 /**
  * ユーザーのアプリケーションサービスのテストクラスです。
@@ -49,7 +50,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testGetUsers_正常系_リポジトリのfindAllを1回呼び出す() {
+  void testGetUsers_正常系_リポジトリのfindAllを1回呼び出す() throws UserValidationException {
     // Arrange
     List<String> names = new ArrayList<>();
     names.add("testName");
@@ -62,7 +63,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testGetUsers_正常系_ユーザーのリストを返す() {
+  void testGetUsers_正常系_ユーザーのリストを返す() throws UserValidationException {
     // Arrange
     List<String> names = new ArrayList<>();
     names.add("testName");
@@ -75,7 +76,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testGetUser_正常系_リポジトリのfindByIdを1回呼び出す() throws UserNotFoundException {
+  void testGetUser_正常系_リポジトリのfindByIdを1回呼び出す() throws UserNotFoundException, UserValidationException {
     // Arrange
     String name = "testName";
     User user = createUser(name);
@@ -88,7 +89,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testGetUser_正常系_指定したidのユーザーを返す() throws UserNotFoundException {
+  void testGetUser_正常系_指定したidのユーザーを返す() throws UserNotFoundException, UserValidationException {
     // Arrange
     String name = "testName";
     User user = createUser(name);
@@ -114,7 +115,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testAddUser_正常系_リポジトリのaddを1回呼び出す() {
+  void testAddUser_正常系_リポジトリのaddを1回呼び出す() throws UserValidationException {
     // Arrange
     String name = "testName";
     User user = createUser(name);
@@ -128,7 +129,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testAddUser_正常系_追加されたユーザーを返す() {
+  void testAddUser_正常系_追加されたユーザーを返す() throws UserValidationException {
     // Arrange
     String name = "testName";
     User user = createUser(name);
@@ -142,7 +143,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testUpdateUser_正常系_リポジトリのupdateを1回呼び出す() throws UserNotFoundException {
+  void testUpdateUser_正常系_リポジトリのupdateを1回呼び出す() throws UserNotFoundException, UserValidationException {
     // Arrange
     String name = "testName";
     User user = createUser(name);
@@ -155,7 +156,7 @@ public class UserApplicationServiceTest {
   }
 
   @Test
-  void testUpdateUser_異常系_更新しようとしたユーザーが存在しない場合UserNotFoundExceptionがスローされる() {
+  void testUpdateUser_異常系_更新しようとしたユーザーが存在しない場合UserNotFoundExceptionがスローされる() throws UserValidationException {
     // Arrange
     String name = "testName";
     User user = createUser(name);
@@ -193,7 +194,7 @@ public class UserApplicationServiceTest {
     assertThrows(UserNotFoundException.class, action);
   }
 
-  private List<User> createUsers(List<String> names) {
+  private List<User> createUsers(List<String> names) throws UserValidationException {
     List<User> users = new ArrayList<>();
     for (String name : names) {
       users.add(createUser(name));
@@ -201,7 +202,7 @@ public class UserApplicationServiceTest {
     return users;
   }
 
-  private User createUser(String name) {
+  private User createUser(String name) throws UserValidationException {
     User user = new User(1L, name, false);
     return user;
   }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryDomainServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryDomainServiceTest.java
@@ -27,7 +27,7 @@ public class DiaryDomainServiceTest {
   }
 
   @Test
-  void testIsExistDiary_正常系_日記が存在する場合はtrueを返す() {
+  void testIsExistDiary_正常系_日記が存在する場合はtrueを返す() throws DiaryValidationException {
     // Arrange
     LocalDate createdDate = LocalDate.of(2025, 1, 1);
     Diary diary = createDiary(createdDate);
@@ -50,7 +50,7 @@ public class DiaryDomainServiceTest {
     assertTrue(!actual);
   }
 
-  private Diary createDiary(LocalDate createdDate) {
+  private Diary createDiary(LocalDate createdDate) throws DiaryValidationException {
     long id = 1;
     long userId = 1;
     String title = "testTitle";

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/diary/DiaryTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
+import com.memoblend.applicationcore.constant.ExceptionIdConstants;
 
 /**
  * Diary クラスのテストクラスです。
@@ -18,92 +19,74 @@ public class DiaryTest {
   }
 
   @Test
-  public void testIdSetZero_正常系_idが0() {
-    assertDoesNotThrow(() -> new Diary(0L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
-  }
-
-  @Test
-  public void testIdIsNegative_異常系_IDが負の数() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> new Diary(-1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 以上の値にしてください", e.getMessage());
-  }
-
-  @Test
-  public void testUserIdSetZero_正常系_userIdが0() {
-    assertDoesNotThrow(() -> new Diary(1L, 0L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
-  }
-
-  @Test
-  public void testUserIdIsNegative_異常系_userIdが負の数() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> new Diary(1L, -1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 以上の値にしてください", e.getMessage());
-  }
-
-  @Test
   public void testTitleIsNull_異常系_titleがnull() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    DiaryValidationException e = assertThrows(
+        DiaryValidationException.class,
         () -> new Diary(1L, 1L, null, "testContent", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
+    assertEquals(ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 
   @Test
   public void testTitleIsBlank_異常系_titleが空白() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> new Diary(1L, 1L, " ", "testContent", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
+    DiaryValidationException e = assertThrows(
+        DiaryValidationException.class,
+        () -> new Diary(1L, 1L, " ", "testContent", LocalDate.of(2025, 1, 1),
+            false));
+    assertEquals(ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 
   @Test
   public void testTitleIsTooShort_異常系_titleが0文字() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    DiaryValidationException e = assertThrows(
+        DiaryValidationException.class,
         () -> new Diary(1L, 1L, "", "testContent", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
+    assertEquals(ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 
   @Test
   public void testTitleIsTooLong_異常系_titleの文字数オーバー() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> new Diary(1L, 1L, "a".repeat(101), "testContent", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} ～ {2} 文字の範囲で入力してください", e.getMessage());
+    DiaryValidationException e = assertThrows(
+        DiaryValidationException.class,
+        () -> new Diary(1L, 1L, "a".repeat(31), "testContent", LocalDate.of(2025, 1,
+            1), false));
+    assertEquals(ExceptionIdConstants.E_DIARY_VALUE_IS_OUT_OF_RANGE, e.getExceptionId());
   }
 
   @Test
   public void testContentIsNull_異常系_contentがnull() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    DiaryValidationException e = assertThrows(
+        DiaryValidationException.class,
         () -> new Diary(1L, 1L, "testTitle", null, LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
+    assertEquals(ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 
   @Test
   public void testContentIsBlank_異常系_contentが空白() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    DiaryValidationException e = assertThrows(DiaryValidationException.class,
         () -> new Diary(1L, 1L, "testTitle", " ", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
+    assertEquals(ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 
   @Test
   public void testContentIsTooShort_異常系_contentが0文字() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    DiaryValidationException e = assertThrows(DiaryValidationException.class,
         () -> new Diary(1L, 1L, "testTitle", "", LocalDate.of(2025, 1, 1), false));
-    assertEquals("{0} は {1} 文字以上入力してください", e.getMessage());
+    assertEquals(ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 
   @Test
-  public void testDateIsNull_異常系_日付がnull() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+  public void testContentIsTooLong_異常系_contentの文字数オーバー() {
+    DiaryValidationException e = assertThrows(
+        DiaryValidationException.class,
+        () -> new Diary(1L, 1L, "testTitle", "a".repeat(1001), LocalDate.of(2025, 1,
+            1), false));
+    assertEquals(ExceptionIdConstants.E_DIARY_VALUE_IS_OUT_OF_RANGE, e.getExceptionId());
+  }
+
+  @Test
+  public void testDateIsNull_異常系_作成日時がnull() {
+    DiaryValidationException e = assertThrows(DiaryValidationException.class,
         () -> new Diary(1L, 1L, "testTitle", "testContent", null, false));
-    assertEquals("{0} は必須です", e.getMessage());
-  }
-
-  @Test
-  public void testIsDeletedIsFalse_正常系_isDeletedがfalse() {
-    assertDoesNotThrow(() -> new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), false));
-  }
-
-  @Test
-  public void testIsDeletedIsTrue_正常系_isDeletedがtrue() {
-    assertDoesNotThrow(() -> new Diary(1L, 1L, "testTitle", "testContent", LocalDate.of(2025, 1, 1), true));
+    assertEquals(ExceptionIdConstants.E_DIARY_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserDomainServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserDomainServiceTest.java
@@ -26,7 +26,7 @@ public class UserDomainServiceTest {
   }
 
   @Test
-  void testIsExistUser_正常系_ユーザーが存在する場合はtrueを返す() {
+  void testIsExistUser_正常系_ユーザーが存在する場合はtrueを返す() throws UserValidationException {
     // Arrange
     String name = "testName";
     User user = createUser(name);
@@ -49,7 +49,7 @@ public class UserDomainServiceTest {
     assertTrue(!actual);
   }
 
-  private User createUser(String name) {
+  private User createUser(String name) throws UserValidationException {
     User user = new User(1L, name, false);
     return user;
   }

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/user/UserTest.java
@@ -14,60 +14,38 @@ import com.memoblend.applicationcore.constant.ExceptionIdConstants;
  */
 @ExtendWith(SpringExtension.class)
 public class UserTest {
-  
+
   @Test
   public void testNoError_正常系_ユーザーを作成できる() {
     // Act
-    assertDoesNotThrow(() -> new User(1L, "testName",false));
-  }
-
-  @Test
-  public void testIdSetZero_正常系_idが0() {
-    assertDoesNotThrow(() -> new User(0L, "testName",false));
-  }
-
-  @Test
-  public void testIdIsNegative_異常系_idが負の数() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> new User(-1L, "testName", false));
-    assertEquals(ExceptionIdConstants.E_USER_ID_IS_NEGATIVE, e.getMessage());
+    assertDoesNotThrow(() -> new User(1L, "testName", false));
   }
 
   @Test
   public void testNameIsNull_異常系_nameがnull() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    UserValidationException e = assertThrows(UserValidationException.class,
         () -> new User(1L, null, false));
-    assertEquals(ExceptionIdConstants.E_USER_NAME_IS_NULL, e.getMessage());
+    assertEquals(ExceptionIdConstants.E_USER_FIELD_IS_REQUIRED, e.getExceptionId());
   }
-  
+
   @Test
   public void testNameIsBlank_異常系_nameが空白() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    UserValidationException e = assertThrows(UserValidationException.class,
         () -> new User(1L, " ", false));
-    assertEquals(ExceptionIdConstants.E_USER_NAME_IS_BLANK, e.getMessage()); 
+    assertEquals(ExceptionIdConstants.E_USER_FIELD_IS_REQUIRED, e.getExceptionId());
   }
 
   @Test
   public void testNameIsTooShort_異常系_nameが0文字() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+    UserValidationException e = assertThrows(UserValidationException.class,
         () -> new User(1L, "", false));
-    assertEquals(ExceptionIdConstants.E_USER_NAME_IS_BLANK, e.getMessage());
+    assertEquals(ExceptionIdConstants.E_USER_FIELD_IS_REQUIRED, e.getExceptionId());
   }
-  
+
   @Test
   public void testNameIsTooLong_異常系_nameの文字数オーバー() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> new User(1L, "a".repeat(999), false));
-    assertEquals(ExceptionIdConstants.E_USER_NAME_LENGTH_IS_OUT_OF_RANGE, e.getMessage());
-  }
-
-  @Test
-  public void testIsDeletedIsFalse_正常系_isDeletedがfalse() {
-    assertDoesNotThrow(() -> new User(1L, "testName",false));
-  }
-
-  @Test
-  public void testIsDeletedIsTrue_正常系_isDeletedがtrue() {
-    assertDoesNotThrow(() -> new User(1L, "testName",true));
+    UserValidationException e = assertThrows(UserValidationException.class,
+        () -> new User(1L, "a".repeat(16), false));
+    assertEquals(ExceptionIdConstants.E_USER_VALUE_IS_OUT_OF_RANGE, e.getExceptionId());
   }
 }

--- a/backend/system-common/src/main/java/com/memoblend/systemcommon/exception/ValidationException.java
+++ b/backend/system-common/src/main/java/com/memoblend/systemcommon/exception/ValidationException.java
@@ -1,0 +1,19 @@
+package com.memoblend.systemcommon.exception;
+
+/**
+ * バリデーションエラー時の例外です。
+ */
+public class ValidationException extends LogicException {
+  /**
+   * 例外 ID 、メッセージ用プレースフォルダ（フロント用）、
+   * メッセージ用プレースフォルダ（ログ用）を指定して、
+   * {@link ValidationException} クラスのインスタンスを初期化します。
+   * 
+   * @param exceptionId       例外 ID 。
+   * @param frontMessageValue メッセージ用プレースフォルダ（フロント用）。
+   * @param logMessageValue   メッセージ用プレースフォルダ（ログ用）。
+   */
+  public ValidationException(String exceptionId, String[] frontMessageValue, String[] logMessageValue) {
+    super(null, exceptionId, frontMessageValue, logMessageValue);
+  }
+}

--- a/backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
@@ -5,6 +5,7 @@ import com.memoblend.applicationcore.applicationservice.DiaryApplicationService;
 import com.memoblend.applicationcore.auth.PermissionDeniedException;
 import com.memoblend.applicationcore.diary.Diary;
 import com.memoblend.applicationcore.diary.DiaryNotFoundException;
+import com.memoblend.applicationcore.diary.DiaryValidationException;
 import com.memoblend.systemcommon.constant.CommonExceptionIdConstants;
 import com.memoblend.systemcommon.constant.SystemPropertyConstants;
 import com.memoblend.web.controller.dto.diary.GetDiariesResponse;
@@ -117,6 +118,7 @@ public class DiaryController {
    * @param request 日記情報。
    * @return 登録結果。
    * @throws PermissionDeniedException 権限エラーが起きた場合。
+   * @throws DiaryValidationException  日記が不正な場合。
    */
   @Operation(summary = "日記情報を登録します。", description = "日記情報を登録します。")
   @ApiResponses(value = {
@@ -127,7 +129,8 @@ public class DiaryController {
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content)
   })
   @PostMapping
-  public ResponseEntity<?> postDiary(@RequestBody PostDiaryRequest request) throws PermissionDeniedException {
+  public ResponseEntity<?> postDiary(@RequestBody PostDiaryRequest request)
+      throws PermissionDeniedException, DiaryValidationException {
     Diary diary = PostDiaryRequestMapper.convert(request);
     Diary addedDiary = diaryApplicationService.addDiary(diary);
     return ResponseEntity.created(URI.create("/api/diary/" + addedDiary.getId())).build();
@@ -172,6 +175,7 @@ public class DiaryController {
    * @param request 日記情報。
    * @return 更新結果。
    * @throws PermissionDeniedException 権限エラーが起きた場合。
+   * @throws DiaryValidationException  日記が不正な場合。
    */
   @Operation(summary = "日記情報を更新します。", description = "日記情報を更新します。")
   @ApiResponses(value = {
@@ -182,7 +186,8 @@ public class DiaryController {
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content),
   })
   @PutMapping
-  public ResponseEntity<?> putDiary(@RequestBody PutDiaryRequest request) throws PermissionDeniedException {
+  public ResponseEntity<?> putDiary(@RequestBody PutDiaryRequest request)
+      throws PermissionDeniedException, DiaryValidationException {
     Diary diary = PutDiaryRequestMapper.convert(request);
     try {
       diaryApplicationService.updateDiary(diary);

--- a/backend/web/src/main/java/com/memoblend/web/controller/UserController.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.memoblend.applicationcore.applicationservice.UserApplicationService;
 import com.memoblend.applicationcore.user.UserNotFoundException;
+import com.memoblend.applicationcore.user.UserValidationException;
 import com.memoblend.applicationcore.user.User;
 import com.memoblend.systemcommon.constant.CommonExceptionIdConstants;
 import com.memoblend.systemcommon.constant.SystemPropertyConstants;
@@ -89,6 +90,7 @@ public class UserController {
    * 
    * @param request ユーザー情報。
    * @return 登録結果。
+   * @throws UserValidationException ユーザーが不正な場合。
    */
   @Operation(summary = "ユーザー情報を登録します。", description = "ユーザー情報を登録します。")
   @ApiResponses(value = {
@@ -97,7 +99,7 @@ public class UserController {
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content)
   })
   @PostMapping
-  public ResponseEntity<?> postUser(@RequestBody PostUserRequest request) {
+  public ResponseEntity<?> postUser(@RequestBody PostUserRequest request) throws UserValidationException {
     User user = PostUserRequestMapper.convert(request);
     User addedUser = userApplicationService.addUser(user);
     return ResponseEntity.created(URI.create("/api/user/" + addedUser.getId())).build();
@@ -139,6 +141,7 @@ public class UserController {
    * 
    * @param request ユーザー情報。
    * @return 更新結果。
+   * @throws UserValidationException ユーザーが不正な場合。
    */
   @Operation(summary = "ユーザー情報を更新します。", description = "ユーザー情報を更新します。")
   @ApiResponses(value = {
@@ -148,7 +151,7 @@ public class UserController {
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content),
   })
   @PutMapping
-  public ResponseEntity<?> putUser(@RequestBody PutUserRequest request) {
+  public ResponseEntity<?> putUser(@RequestBody PutUserRequest request) throws UserValidationException {
     User user = PutUserRequestMapper.convert(request);
     try {
       userApplicationService.updateUser(user);

--- a/backend/web/src/main/java/com/memoblend/web/controller/advice/ExceptionHandlerControllerAdvice.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/advice/ExceptionHandlerControllerAdvice.java
@@ -16,6 +16,7 @@ import com.memoblend.systemcommon.constant.CommonExceptionIdConstants;
 import com.memoblend.systemcommon.constant.SystemPropertyConstants;
 import com.memoblend.systemcommon.exception.LogicException;
 import com.memoblend.systemcommon.exception.SystemException;
+import com.memoblend.systemcommon.exception.ValidationException;
 import com.memoblend.web.controller.util.ProblemDetailsFactory;
 import com.memoblend.web.log.ErrorMessageBuilder;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,6 +33,25 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
   private ProblemDetailsFactory problemDetailsFactory;
 
   /**
+   * バリデーションエラーをステータスコード 400 で返却します。
+   * 
+   * @param e バリデーションエラー。
+   * @return ステータスコード 400 のレスポンス。
+   */
+  @ExceptionHandler(ValidationException.class)
+  public ResponseEntity<ProblemDetail> handleValidationException(ValidationException e) {
+    apLog.info(e.getMessage());
+    apLog.debug(ExceptionUtils.getStackTrace(e));
+    ErrorMessageBuilder errorBuilder = new ErrorMessageBuilder(
+        e, e.getExceptionId(), e.getFrontMessageValue(), e.getLogMessageValue());
+    ProblemDetail problemDetail = problemDetailsFactory.createProblemDetail(errorBuilder,
+        CommonExceptionIdConstants.E_BUSINESS, HttpStatus.BAD_REQUEST);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .body(problemDetail);
+  }
+
+  /**
    * 権限エラーをステータスコード 404 で返却します。
    * 
    * @param e 権限エラー。
@@ -41,8 +61,8 @@ public class ExceptionHandlerControllerAdvice extends ResponseEntityExceptionHan
   public ResponseEntity<ProblemDetail> handlePermissionDeniedException(PermissionDeniedException e) {
     apLog.info(e.getMessage());
     apLog.debug(ExceptionUtils.getStackTrace(e));
-    ErrorMessageBuilder errorBuilder = new ErrorMessageBuilder(e, e.getExceptionId(),
-        e.getLogMessageValue(), e.getFrontMessageValue());
+    ErrorMessageBuilder errorBuilder = new ErrorMessageBuilder(e, e.getExceptionId(), e.getFrontMessageValue(),
+        e.getLogMessageValue());
     ProblemDetail problemDetail = problemDetailsFactory.createProblemDetail(errorBuilder,
         CommonExceptionIdConstants.E_BUSINESS, HttpStatus.NOT_FOUND);
     return ResponseEntity.status(HttpStatus.NOT_FOUND)

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PostDiaryRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PostDiaryRequestMapper.java
@@ -1,6 +1,7 @@
 package com.memoblend.web.controller.mapper.diary;
 
 import com.memoblend.applicationcore.diary.Diary;
+import com.memoblend.applicationcore.diary.DiaryValidationException;
 import com.memoblend.web.controller.dto.diary.PostDiaryRequest;
 
 /**
@@ -13,8 +14,9 @@ public class PostDiaryRequestMapper {
    * 
    * @param request リクエスト。
    * @return 日記。
+   * @throws DiaryValidationException 日記が不正な場合。
    */
-  public static Diary convert(PostDiaryRequest request) {
+  public static Diary convert(PostDiaryRequest request) throws DiaryValidationException {
     Diary diary = new Diary(
         0,
         request.getUserId(),

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PutDiaryRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/diary/PutDiaryRequestMapper.java
@@ -1,6 +1,7 @@
 package com.memoblend.web.controller.mapper.diary;
 
 import com.memoblend.applicationcore.diary.Diary;
+import com.memoblend.applicationcore.diary.DiaryValidationException;
 import com.memoblend.web.controller.dto.diary.PutDiaryRequest;
 
 /**
@@ -13,8 +14,9 @@ public class PutDiaryRequestMapper {
    * 
    * @param request 日記の更新リクエスト。
    * @return 日記。
+   * @throws DiaryValidationException 日記が不正な場合。
    */
-  public static Diary convert(PutDiaryRequest request) {
+  public static Diary convert(PutDiaryRequest request) throws DiaryValidationException {
     Diary diary = new Diary(
         request.getId(),
         request.getUserId(),

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PostUserRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PostUserRequestMapper.java
@@ -1,6 +1,7 @@
 package com.memoblend.web.controller.mapper.user;
 
 import com.memoblend.applicationcore.user.User;
+import com.memoblend.applicationcore.user.UserValidationException;
 import com.memoblend.web.controller.dto.user.PostUserRequest;
 
 /**
@@ -13,8 +14,9 @@ public class PostUserRequestMapper {
    * 
    * @param request リクエスト。
    * @return ユーザー。
+   * @throws UserValidationException ユーザーが不正な場合。
    */
-  public static User convert(PostUserRequest request) {
+  public static User convert(PostUserRequest request) throws UserValidationException {
     User user = new User(
         0,
         request.getName(),

--- a/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PutUserRequestMapper.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/mapper/user/PutUserRequestMapper.java
@@ -1,6 +1,7 @@
 package com.memoblend.web.controller.mapper.user;
 
 import com.memoblend.applicationcore.user.User;
+import com.memoblend.applicationcore.user.UserValidationException;
 import com.memoblend.web.controller.dto.user.PutUserRequest;
 
 /**
@@ -13,8 +14,9 @@ public class PutUserRequestMapper {
    * 
    * @param request ユーザーの更新リクエスト。
    * @return ユーザー。
+   * @throws UserValidationException ユーザーが不正な場合。
    */
-  public static User convert(PutUserRequest request) {
+  public static User convert(PutUserRequest request) throws UserValidationException {
     User user = new User(
         request.getId(),
         request.getName(),

--- a/backend/web/src/main/java/com/memoblend/web/log/ErrorMessageBuilder.java
+++ b/backend/web/src/main/java/com/memoblend/web/log/ErrorMessageBuilder.java
@@ -21,8 +21,8 @@ public class ErrorMessageBuilder {
 
   private Exception ex;
   private String exceptionId;
-  private String[] logMessageValue;
   private String[] frontMessageValue;
+  private String[] logMessageValue;
 
   /**
    * ProblemDetails の detail 情報に格納するスタックトレースを作成します。

--- a/frontend/diary/src/views/diary/DiaryDetailView.vue
+++ b/frontend/diary/src/views/diary/DiaryDetailView.vue
@@ -7,7 +7,6 @@ import { onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 
 const customErrorHandler = useCustomErrorHandler();
-
 const route = useRoute();
 const id = Number(route.params.id);
 const showLoading = ref(true);
@@ -17,7 +16,7 @@ const showLoading = ref(true);
  */
 const diary = ref<GetDiaryResponse>({
   content: '',
-  date: '',
+  createdDate: '',
   id: id,
   title: '',
   userId: 0,
@@ -74,7 +73,7 @@ onMounted(async () => {
   <LoadingSpinnerOverlay :isLoading="showLoading" />
   <v-container v-if="!showLoading">
     <h1>{{ diary.title }}</h1>
-    <p>{{ diary.date }}</p>
+    <p>{{ diary.createdDate }}</p>
     <p>{{ diary.content }}</p>
     <div class="mt-4">
       <v-btn class="mr-4" @click="goToEditDiary">編集</v-btn>

--- a/frontend/diary/src/views/diary/DiaryEditView.vue
+++ b/frontend/diary/src/views/diary/DiaryEditView.vue
@@ -5,6 +5,7 @@ import { onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { format } from 'date-fns';
 import { useCustomErrorHandler } from '@/shared/error-handler/use-custom-error-handler';
+import { LoadingSpinnerOverlay } from '@/components/organisms/LoadingSpinnerOverlay';
 
 const customErrorHandler = useCustomErrorHandler();
 const route = useRoute();
@@ -15,7 +16,7 @@ const showLoading = ref(true);
  */
 const diary = ref<PutDiaryRequest>({
   content: '',
-  date: '',
+  createdDate: '',
   id: id,
   title: '',
   userId: 0,
@@ -34,7 +35,7 @@ const router = useRouter();
  */
 const updateDiaryAsync = async () => {
   if (selectedDate.value) {
-    diary.value.date = format(selectedDate.value, 'yyyy-MM-dd');
+    diary.value.createdDate = format(selectedDate.value, 'yyyy-MM-dd');
   }
   await updateDiary(diary.value);
   router.push({ name: 'diaries' });
@@ -44,7 +45,7 @@ onMounted(async () => {
   showLoading.value = true;
   try {
     const response = await getDiary(id);
-    selectedDate.value = response.date ? new Date(response.date) : null;
+    selectedDate.value = response.createdDate ? new Date(response.createdDate) : null;
     diary.value = response;
   }
   catch (error) {


### PR DESCRIPTION
## 本プルリクエストで実施したこと
- 例外メッセージの定数管理を集約しました。
- バリデーションエラー専用の例外クラスを追加しました。
- IdとuserIdのバリデーションを削除しました。
- その他な軽微な修正を行いました。

## 本プルリクエストで実施していないこと
- ログのリグレッションテストは追加していません。

## 関連Issue、参考ページ
- #324 
- #301 
- #207 
- #208 