### PR TITLE
not foundページを実装

### DIFF
--- a/frontend/diary/src/router/error/index.ts
+++ b/frontend/diary/src/router/error/index.ts
@@ -10,4 +10,8 @@ export const errorRoutes: RouteRecordRaw[] = [
       requiresAuth: false,
     },
   },
+  {
+    path: '/:pathMatch(.*)*',
+    component: () => import('@/views/error/NotFoundView.vue')
+  },
 ];

--- a/frontend/diary/src/router/index.ts
+++ b/frontend/diary/src/router/index.ts
@@ -5,5 +5,5 @@ import { authenticationRoutes } from './authentication';
 
 export const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
-  routes: [...diaryRoutes, ...errorRoutes, ...authenticationRoutes],
+  routes: [...diaryRoutes, ...authenticationRoutes, ...errorRoutes,],
 });

--- a/frontend/diary/src/views/error/NotFoundView.vue
+++ b/frontend/diary/src/views/error/NotFoundView.vue
@@ -1,9 +1,18 @@
 <script setup lang="ts">
+import { useRouter } from 'vue-router';
+const router = useRouter();
+const goHome = () => router.push({ name: 'diaries' });
 </script>
 
 <template>
-  <div class="not-found">
-    <h1>404 Not Found</h1>
-    <p>The page you are looking for does not exist.</p>
-  </div>
+  <v-container class="fill-height d-flex align-center justify-center">
+    <v-row justify="center">
+      <v-col cols="12" md="8" class="text-center">
+        <v-icon size="96" color="grey">mdi-alert-circle-outline</v-icon>
+        <h1 class="display-2 font-weight-bold mb-2">404 Not Found</h1>
+        <p class="mb-6">お探しのページは見つかりませんでした。</p>
+        <v-btn color="primary" @click="goHome" large>ホームに戻る</v-btn>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>

--- a/frontend/diary/src/views/error/NotFoundView.vue
+++ b/frontend/diary/src/views/error/NotFoundView.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="not-found">
+    <h1>404 Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+  </div>
+</template>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 本プルリクエストで実施したこと
どのルーティングにもマッチしなかったパスにアクセスした際に404ページに飛ぶようにしました。

## 本プルリクエストで実施していないこと
なし

## 関連Issue、参考ページ
- #521 

## レビュでの確認事項と手順
1. バックエンドとフロントエンドをそれぞれ立ち上げて下さい
2. localhost:5173/unknownなどの存在しないページにアクセスして、404ページに飛ぶことを確認して下さい

<!-- I want to review in Japanese. -->