### PR TITLE
日記の全件取得を年月ごとの取得に改変

### DIFF
--- a/backend/api-docs/web/api-specification.json
+++ b/backend/api-docs/web/api-specification.json
@@ -22,6 +22,76 @@
   ],
   "paths": {
     "/api/diary": {
+      "get": {
+        "description": "年月を指定して、日記を取得します。",
+        "operationId": "getDiaries",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "in": "query",
+            "name": "month",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetDiariesResponse"
+                }
+              }
+            },
+            "description": "成功。"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "未認証。"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "対応した日記が存在しません。"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            },
+            "description": "サーバーエラー。"
+          }
+        },
+        "summary": "年月を指定して、日記を取得します。",
+        "tags": [
+          "Diary"
+        ]
+      },
       "post": {
         "description": "日記情報を登録します。",
         "operationId": "postDiary",
@@ -149,59 +219,7 @@
         ]
       }
     },
-    "/api/diary/list": {
-      "get": {
-        "description": "日記を全件取得します。",
-        "operationId": "getDiaries",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetDiariesResponse"
-                }
-              }
-            },
-            "description": "成功。"
-          },
-          "401": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "未認証。"
-          },
-          "404": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "対応した日記が存在しません。"
-          },
-          "500": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetail"
-                }
-              }
-            },
-            "description": "サーバーエラー。"
-          }
-        },
-        "summary": "日記を全件取得します。",
-        "tags": [
-          "Diary"
-        ]
-      }
-    },
-    "/api/diary/list/{userId}": {
+    "/api/diary/user/{userId}": {
       "get": {
         "description": "UserID を指定して、日記を全件取得します。",
         "operationId": "getDiariesByUserId",

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationService.java
@@ -33,17 +33,28 @@ public class DiaryApplicationService {
   private final Logger apLog = Logger.getLogger(SystemPropertyConstants.APPLICATION_LOGGER);
 
   /**
-   * 全ての日記をリストで取得します。
+   * 年月を指定して、日記をリストで取得します。
+   * 指定された年が null の場合、現在の年を使用します。
+   * 指定された月が null または 1 から 12 の範囲外の場合、現在の月を使用します。
    * 
-   * @return 全ての日記のリスト。
+   * @param year  年。
+   * @param month 月。
+   * @return 指定した年月の日記のリスト。
    * @throws PermissionDeniedException 認可が拒否された場合。
    */
-  public List<Diary> getDiaries() throws PermissionDeniedException {
-    apLog.info(messages.getMessage(MessageIdConstants.D_DIARY_GET_DIARIES, new Object[] {}, Locale.getDefault()));
-    if (!userStore.isInRole(UserRoleConstants.USER)) {
-      throw new PermissionDeniedException("getDiaries");
+  public List<Diary> getDiariesByYearAndMonth(Integer year, Integer month) throws PermissionDeniedException {
+    if (year == null) {
+      year = LocalDate.now().getYear();
     }
-    return diaryRepository.findAll();
+    if (month == null || month < 1 || month > 12) {
+      month = LocalDate.now().getMonthValue();
+    }
+    apLog.info(messages.getMessage(MessageIdConstants.D_DIARY_GET_DIARIES_BY_YEAR_AND_MONTH,
+        new Object[] { year, month }, Locale.getDefault()));
+    if (!userStore.isInRole(UserRoleConstants.USER)) {
+      throw new PermissionDeniedException("getDiariesByYearAndMonth");
+    }
+    return diaryRepository.findByYearAndMonth(year, month);
   }
 
   /**

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/constant/MessageIdConstants.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/constant/MessageIdConstants.java
@@ -5,8 +5,8 @@ package com.memoblend.applicationcore.constant;
  */
 public class MessageIdConstants {
 
-  /** 日記の一覧を取得します。 */
-  public static final String D_DIARY_GET_DIARIES = "diaryApplicationServiceGetDiaries";
+  /** {}年{}月の日記の一覧を取得します。 */
+  public static final String D_DIARY_GET_DIARIES_BY_YEAR_AND_MONTH = "diaryApplicationServiceGetDiariesByYearAndMonth";
 
   /** ユーザーID：{0} の日記の一覧を取得します。 */
   public static final String D_DIARY_GET_DIARIES_BY_USER_ID = "diaryApplicationServiceGetDiariesByUserId";

--- a/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryRepository.java
+++ b/backend/application-core/src/main/java/com/memoblend/applicationcore/diary/DiaryRepository.java
@@ -8,11 +8,13 @@ import java.util.List;
 public interface DiaryRepository {
 
   /**
-   * 全ての日記を取得します。
+   * 年月を指定して、日記を取得します。
    * 
-   * @return 全ての日記。
+   * @param year  年。
+   * @param month 月（1 から 12 の範囲）。
+   * @return 指定した年月の日記のリスト。
    */
-  List<Diary> findAll();
+  List<Diary> findByYearAndMonth(int year, int month);
 
   /**
    * ID を指定して、日記を取得します。

--- a/backend/application-core/src/main/resources/applicationcore/messages.properties
+++ b/backend/application-core/src/main/resources/applicationcore/messages.properties
@@ -6,7 +6,7 @@ diaryFieldIsRequired=日記の{0}は必須です。
 diaryValueIsOutOfRange=日記の{0}は{1}～{2}の範囲で入力してください。
 
 # 通知用メッセージ
-diaryApplicationServiceGetDiaries=日記の一覧を取得します。
+diaryApplicationServiceGetDiariesByYearAndMonth={0}年{1}月の日記の一覧を取得します。
 diaryApplicationServiceGetDiary=日記ID:{0}の日記を取得します。
 diaryApplicationServiceAddDiary={0}年{1}月{2}日の日記を追加します。
 diaryApplicationServiceUpdateDiary=日記ID:{0}の日記を更新します。

--- a/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationServiceTest.java
+++ b/backend/application-core/src/test/java/com/memoblend/applicationcore/applicationservice/DiaryApplicationServiceTest.java
@@ -57,44 +57,45 @@ class DiaryApplicationServiceTest {
   }
 
   @Test
-  void testGetDiaries_正常系_リポジトリのfindAllを1回呼び出す() throws PermissionDeniedException, DiaryValidationException {
+  void testGetDiariesByYearAndMonth_正常系_リポジトリのfindByYearAndMonthを1回呼び出す()
+      throws PermissionDeniedException, DiaryValidationException {
     // Arrange
-    List<LocalDate> dates = new ArrayList<>();
-    dates.add(LocalDate.of(2025, 1, 1));
-    List<Diary> diaries = createDiaries(dates);
-    when(diaryRepository.findAll()).thenReturn(diaries);
+    int year = 2025;
+    int month = 1;
+    List<Diary> diaries = createDiaries(List.of(LocalDate.of(year, month, 1)));
+    when(diaryRepository.findByYearAndMonth(year, month)).thenReturn(diaries);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(true);
     // Act
-    diaryApplicationService.getDiaries();
+    diaryApplicationService.getDiariesByYearAndMonth(year, month);
     // Assert
-    verify(diaryRepository, times(1)).findAll();
+    verify(diaryRepository, times(1)).findByYearAndMonth(year, month);
   }
 
   @Test
-  void testGetDiaries_正常系_日記のリストを返す() throws PermissionDeniedException, DiaryValidationException {
+  void testGetDiariesByYearAndMonth_正常系_日記のリストを返す() throws PermissionDeniedException, DiaryValidationException {
     // Arrange
-    List<LocalDate> dates = new ArrayList<>();
-    dates.add(LocalDate.of(2025, 1, 1));
-    List<Diary> diaries = createDiaries(dates);
-    when(diaryRepository.findAll()).thenReturn(diaries);
+    int year = 2025;
+    int month = 1;
+    List<Diary> diaries = createDiaries(List.of(LocalDate.of(year, month, 1)));
+    when(diaryRepository.findByYearAndMonth(year, month)).thenReturn(diaries);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(true);
     // Act
-    List<Diary> actual = diaryApplicationService.getDiaries();
+    List<Diary> actual = diaryApplicationService.getDiariesByYearAndMonth(year, month);
     // Assert
     assertThat(actual).isEqualTo(diaries);
   }
 
   @Test
-  void testGetDiaries_異常系_権限がない場合にPermissionDeniedExceptionが発生する() throws DiaryValidationException {
+  void testGetDiariesByYearAndMonth_異常系_権限がない場合にPermissionDeniedExceptionが発生する() throws DiaryValidationException {
     // Arrange
-    List<LocalDate> dates = new ArrayList<>();
-    dates.add(LocalDate.of(2025, 1, 1));
-    List<Diary> diaries = createDiaries(dates);
-    when(diaryRepository.findAll()).thenReturn(diaries);
+    int year = 2025;
+    int month = 1;
+    List<Diary> diaries = createDiaries(List.of(LocalDate.of(year, month, 1)));
+    when(diaryRepository.findByYearAndMonth(year, month)).thenReturn(diaries);
     when(userStore.isInRole(UserRoleConstants.USER)).thenReturn(false);
     // Act
     Executable action = () -> {
-      diaryApplicationService.getDiaries();
+      diaryApplicationService.getDiariesByYearAndMonth(year, month);
     };
     // Assert
     assertThrows(PermissionDeniedException.class, action);

--- a/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/MyBatisDiaryRepository.java
+++ b/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/MyBatisDiaryRepository.java
@@ -17,8 +17,8 @@ public class MyBatisDiaryRepository implements DiaryRepository {
   private final DiaryMapper diaryMapper;
 
   @Override
-  public List<Diary> findAll() {
-    return diaryMapper.findAll();
+  public List<Diary> findByYearAndMonth(int year, int month) {
+    return diaryMapper.findByYearAndMonth(year, month);
   }
 
   @Override

--- a/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.java
+++ b/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.java
@@ -11,11 +11,13 @@ import com.memoblend.applicationcore.diary.Diary;
 public interface DiaryMapper {
 
   /**
-   * 日記を全件取得します。
+   * 年月を指定して、日記を取得します。
    * 
-   * @return 全ての日記。
+   * @param year  年。
+   * @param month 月。
+   * @return 指定した年月の日記のリスト。
    */
-  public List<Diary> findAll();
+  public List<Diary> findByYearAndMonth(int year, int month);
 
   /**
    * ユーザー ID を指定して、日記を取得します。

--- a/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.xml
+++ b/backend/infrastructure/src/main/java/com/memoblend/infrastructure/repository/mapper/DiaryMapper.xml
@@ -2,12 +2,16 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
 <mapper namespace="com.memoblend.infrastructure.repository.mapper.DiaryMapper">
 
-	<select id="findAll" resultType="com.memoblend.applicationcore.diary.Diary">
+	<select id="findByYearAndMonth" resultType="com.memoblend.applicationcore.diary.Diary">
 		SELECT * FROM diaries
 		<where>
-			<if test="isDeleted != null">
-				is_deleted = false
+			<if test="year != null">
+				YEAR(created_date) = #{year}
 			</if>
+			<if test="month != null">
+				AND MONTH(created_date) = #{month}
+			</if>
+			AND is_deleted = false
 		</where>
 	</select>
 
@@ -17,24 +21,19 @@
 			<if test="id != null">
 				id = #{id}
 			</if>
-			<if test="isDeleted != null">
-				AND is_deleted = false
-			</if>
+			AND is_deleted = false
 		</where>
 	</select>
-
 	<select id="findByUserId" resultType="com.memoblend.applicationcore.diary.Diary">
 		SELECT * FROM diaries
 		<where>
 			<if test="userId != null">
 				user_id = #{userId}
 			</if>
-			<if test="isDeleted != null">
-				AND is_deleted = false
-			</if>
+			AND is_deleted = false
 		</where>
 	</select>
-	
+
 	<insert id="add" parameterType="com.memoblend.applicationcore.diary.Diary" useGeneratedKeys="true" keyProperty="id">
 		INSERT INTO diaries (user_id, title, content, created_date)
 		VALUES (#{userId}, #{title}, #{content}, #{createdDate})

--- a/backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
+++ b/backend/web/src/main/java/com/memoblend/web/controller/DiaryController.java
@@ -37,6 +37,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -55,21 +56,23 @@ public class DiaryController {
   private static final Logger apLog = LoggerFactory.getLogger(SystemPropertyConstants.APPLICATION_LOGGER);
 
   /**
-   * 日記を全件取得します。
+   * 年月を指定して、日記を取得します。
    * 
    * @return 日記情報。
    * @throws PermissionDeniedException 権限エラーが起きた場合。
    */
-  @Operation(summary = "日記を全件取得します。", description = "日記を全件取得します。")
+  @Operation(summary = "年月を指定して、日記を取得します。", description = "年月を指定して、日記を取得します。")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "成功。", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = GetDiariesResponse.class))),
       @ApiResponse(responseCode = "401", description = "未認証。", content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class))),
       @ApiResponse(responseCode = "404", description = "対応した日記が存在しません。", content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class))),
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)))
   })
-  @GetMapping("list")
-  public ResponseEntity<GetDiariesResponse> getDiaries() throws PermissionDeniedException {
-    List<Diary> diaries = diaryApplicationService.getDiaries();
+  @GetMapping()
+  public ResponseEntity<GetDiariesResponse> getDiaries(@RequestParam(required = false) Integer year,
+      @RequestParam(required = false) Integer month)
+      throws PermissionDeniedException {
+    List<Diary> diaries = diaryApplicationService.getDiariesByYearAndMonth(year, month);
     GetDiariesResponse response = GetDiariesResponseMapper.convert(diaries);
     return ResponseEntity.ok().body(response);
   }
@@ -88,8 +91,8 @@ public class DiaryController {
       @ApiResponse(responseCode = "404", description = "対応した日記が存在しません。", content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class))),
       @ApiResponse(responseCode = "500", description = "サーバーエラー。", content = @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = ProblemDetail.class)))
   })
-  @GetMapping("list/{userId}")
-  public ResponseEntity<GetDiariesResponse> getDiariesByUserId(@PathVariable("userId") long userId)
+  @GetMapping("user/{userId}")
+  public ResponseEntity<GetDiariesResponse> getDiariesByUserId(@PathVariable Long userId)
       throws PermissionDeniedException {
     List<Diary> diaries = diaryApplicationService.getDiariesByUserId(userId);
     GetDiariesResponse response = GetDiariesResponseMapper.convert(diaries);

--- a/backend/web/src/test/java/com/memoblend/web/controller/DiaryControllerTest.java
+++ b/backend/web/src/test/java/com/memoblend/web/controller/DiaryControllerTest.java
@@ -31,31 +31,39 @@ class DiaryControllerTest {
 
   @Test
   @WithMockUser
-  void testGetDiaries_正常系_日記のリストを返す() throws Exception {
-    this.mockMvc.perform(get("/api/diary/list"))
+  void testGetDiariesByYearAndMonth_正常系_指定の年月の日記のリストを返す() throws Exception {
+    this.mockMvc.perform(get("/api/diary?year=2025&month=4"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON));
   }
 
   @Test
-  void testGetDiaries_異常系_権限が足りない() throws Exception {
-    this.mockMvc.perform(get("/api/diary/list"))
+  @WithMockUser
+  void testGetDiariesByYearAndMonth_正常系_年月未指定の場合に当年月の日記のリストを返す() throws Exception {
+    this.mockMvc.perform(get("/api/diary"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void testGetDiariesByYearAndMonth_異常系_権限が足りない() throws Exception {
+    this.mockMvc.perform(get("/api/diary"))
         .andExpect(status().isNotFound());
   }
 
   @Test
   @WithMockUser
   void testGetDiariesByUserId_正常系_日記のリストを返す() throws Exception {
-    long userId = 1;
-    this.mockMvc.perform(get("/api/diary/list/" + userId))
+    Long userId = 1L;
+    this.mockMvc.perform(get("/api/diary/user/" + userId))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON));
   }
 
   @Test
   void testGetDiariesByUserId_異常系_権限が足りない() throws Exception {
-    long userId = 1;
-    this.mockMvc.perform(get("/api/diary/list/" + userId))
+    Long userId = 1L;
+    this.mockMvc.perform(get("/api/diary/user/" + userId))
         .andExpect(status().isNotFound());
   }
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 本プルリクエストで実施したこと
- 日記の全件取得を年月ごとの取得に改変しました。
- ユーザーIDごとの日記の取得URLを変更しました。

## 本プルリクエストで実施していないこと
- フロントエンドコードの再生性は実施していません
- 分析AIのURL定義は変更していません

## 関連Issue、参考ページ
- #552 
- #256 

## レビューでの確認事項と手順
1. バックエンドアプリケーションを起動する（`./gradlew web:bootrundev`）
2. localhost:8080/api/diaryにアクセスして、2025年6月の日記が取得できることを確認する（おそらくからの配列がかえる）
3. localhost:8080/api/diary?year=2025&month=3にアクセスして、2025年3月の日記が取得できることを確認する
<!-- I want to review in Japanese. -->